### PR TITLE
Update EnvVar.cpp

### DIFF
--- a/EnvVar.cpp
+++ b/EnvVar.cpp
@@ -23,9 +23,12 @@
 
 #include <cassert>
 #include <limits>
-#include <windows.h>
 
-#undef max // unbelievable
+#ifndef NOMINMAX // We do not need min and max macroses from <Windows.h>
+#define NOMINMAX
+#endif
+
+#include <windows.h>
 
 #include "EnvVar.hpp"
 


### PR DESCRIPTION
Instead of undefining max, clearer will be defining NOMINMAX, to prevent min and max macroses definition inside <windows.h>